### PR TITLE
Fix Named Objects permissions

### DIFF
--- a/DebugView++Lib/DBWinReader.cpp
+++ b/DebugView++Lib/DBWinReader.cpp
@@ -11,6 +11,8 @@
 #include "DebugView++Lib/ProcessInfo.h"
 #include "DebugView++Lib/LineBuffer.h"
 #include "CobaltFusion/stringbuilder.h"
+#include <AccCtrl.h>
+#include <Aclapi.h>
 
 namespace fusion {
 namespace debugviewpp {
@@ -28,18 +30,24 @@ Win32::Handle CreateDBWinBufferMapping(bool global)
 	Win32::Handle hMap(CreateFileMapping(nullptr, nullptr, PAGE_READWRITE, 0, sizeof(DbWinBuffer), GetDBWinName(global, L"DBWIN_BUFFER").c_str()));
 	if (GetLastError() == ERROR_ALREADY_EXISTS)
 		throw std::runtime_error("CreateDBWinBufferMapping");
-	return hMap;
+	SetSecurityInfo(hMap.get(), SE_KERNEL_OBJECT, DACL_SECURITY_INFORMATION, nullptr, nullptr, nullptr, nullptr);
+    return hMap;
 }
 
 DBWinReader::DBWinReader(Timer& timer, ILineBuffer& linebuffer, bool global) :
 	LogSource(timer, SourceType::System, linebuffer),
 	m_hBuffer(CreateDBWinBufferMapping(global)),
+
 	m_dbWinBufferReady(Win32::CreateEvent(nullptr, false, true, GetDBWinName(global, L"DBWIN_BUFFER_READY").c_str())),
 	m_dbWinDataReady(Win32::CreateEvent(nullptr, false, false, GetDBWinName(global, L"DBWIN_DATA_READY").c_str())),
 	m_mappedViewOfFile(m_hBuffer.get(), PAGE_READONLY, 0, 0, sizeof(DbWinBuffer)),
 	m_dbWinBuffer(static_cast<const DbWinBuffer*>(m_mappedViewOfFile.Ptr()))
 {
 	SetDescription(global ? L"Global Win32 Messages" : L"Win32 Messages");
+
+	SetSecurityInfo(m_dbWinBufferReady.get(), SE_KERNEL_OBJECT, DACL_SECURITY_INFORMATION, nullptr, nullptr, nullptr, nullptr);
+	SetSecurityInfo(m_dbWinDataReady.get(), SE_KERNEL_OBJECT, DACL_SECURITY_INFORMATION, nullptr, nullptr, nullptr, nullptr);
+
 	Win32::SetEvent(m_dbWinBufferReady);
 }
 

--- a/DebugView++Lib/DBWinReader.cpp
+++ b/DebugView++Lib/DBWinReader.cpp
@@ -11,8 +11,6 @@
 #include "DebugView++Lib/ProcessInfo.h"
 #include "DebugView++Lib/LineBuffer.h"
 #include "CobaltFusion/stringbuilder.h"
-#include <AccCtrl.h>
-#include <Aclapi.h>
 
 namespace fusion {
 namespace debugviewpp {
@@ -30,7 +28,7 @@ Win32::Handle CreateDBWinBufferMapping(bool global)
 	Win32::Handle hMap(CreateFileMapping(nullptr, nullptr, PAGE_READWRITE, 0, sizeof(DbWinBuffer), GetDBWinName(global, L"DBWIN_BUFFER").c_str()));
 	if (GetLastError() == ERROR_ALREADY_EXISTS)
 		throw std::runtime_error("CreateDBWinBufferMapping");
-	SetSecurityInfo(hMap.get(), SE_KERNEL_OBJECT, DACL_SECURITY_INFORMATION, nullptr, nullptr, nullptr, nullptr);
+	Win32::SetSecurityInfo(hMap.get(), SE_KERNEL_OBJECT, DACL_SECURITY_INFORMATION, nullptr, nullptr, nullptr, nullptr);
     return hMap;
 }
 
@@ -45,8 +43,8 @@ DBWinReader::DBWinReader(Timer& timer, ILineBuffer& linebuffer, bool global) :
 {
 	SetDescription(global ? L"Global Win32 Messages" : L"Win32 Messages");
 
-	SetSecurityInfo(m_dbWinBufferReady.get(), SE_KERNEL_OBJECT, DACL_SECURITY_INFORMATION, nullptr, nullptr, nullptr, nullptr);
-	SetSecurityInfo(m_dbWinDataReady.get(), SE_KERNEL_OBJECT, DACL_SECURITY_INFORMATION, nullptr, nullptr, nullptr, nullptr);
+	Win32::SetSecurityInfo(m_dbWinBufferReady.get(), SE_KERNEL_OBJECT, DACL_SECURITY_INFORMATION, nullptr, nullptr, nullptr, nullptr);
+	Win32::SetSecurityInfo(m_dbWinDataReady.get(), SE_KERNEL_OBJECT, DACL_SECURITY_INFORMATION, nullptr, nullptr, nullptr, nullptr);
 
 	Win32::SetEvent(m_dbWinBufferReady);
 }

--- a/DebugView++Lib/DBWinReader.cpp
+++ b/DebugView++Lib/DBWinReader.cpp
@@ -23,12 +23,47 @@ std::wstring GetDBWinName(bool global, const std::wstring& name)
 	return global ? L"Global\\" + name : name;
 }
 
+//delete DACL at all, so permit Full Access for Everyone
+void DeleteObjectDACL(HANDLE hObject)
+{
+	Win32::SetSecurityInfo(hObject, SE_KERNEL_OBJECT, DACL_SECURITY_INFORMATION, nullptr, nullptr, nullptr, nullptr);
+}
+
+//add necessary permissions for "Authenticated Users" group (all non-anonymous users)
+void AdjustObjectDACL(HANDLE hObject)
+{
+	ACL* pOldDACL;
+	SECURITY_DESCRIPTOR* pSD = NULL;
+	GetSecurityInfo(hObject, SE_KERNEL_OBJECT, DACL_SECURITY_INFORMATION, nullptr, nullptr, &pOldDACL, nullptr, (void**)&pSD);
+
+	PSID pSid = NULL;
+	SID_IDENTIFIER_AUTHORITY authNt = SECURITY_NT_AUTHORITY;
+	AllocateAndInitializeSid(&authNt, 1, SECURITY_AUTHENTICATED_USER_RID, 0, 0, 0, 0, 0, 0, 0, &pSid);
+
+	EXPLICIT_ACCESS ea = { 0 };
+	ea.grfAccessMode = GRANT_ACCESS;
+	ea.grfAccessPermissions = GENERIC_READ | GENERIC_WRITE | GENERIC_EXECUTE;
+	ea.grfInheritance = NO_INHERITANCE;
+	ea.Trustee.TrusteeType = TRUSTEE_IS_GROUP;
+	ea.Trustee.TrusteeForm = TRUSTEE_IS_SID;
+	ea.Trustee.ptstrName = (LPTSTR)pSid;
+
+	ACL* pNewDACL = 0;
+	SetEntriesInAcl(1, &ea, pOldDACL, &pNewDACL);
+
+	Win32::SetSecurityInfo(hObject, SE_KERNEL_OBJECT, DACL_SECURITY_INFORMATION, nullptr, nullptr, pNewDACL, nullptr);
+
+	FreeSid(pSid);
+	LocalFree(pNewDACL);
+	LocalFree(pSD);
+	LocalFree(pOldDACL);
+}
+
 Win32::Handle CreateDBWinBufferMapping(bool global)
 {
 	Win32::Handle hMap(CreateFileMapping(nullptr, nullptr, PAGE_READWRITE, 0, sizeof(DbWinBuffer), GetDBWinName(global, L"DBWIN_BUFFER").c_str()));
 	if (GetLastError() == ERROR_ALREADY_EXISTS)
 		throw std::runtime_error("CreateDBWinBufferMapping");
-	Win32::SetSecurityInfo(hMap.get(), SE_KERNEL_OBJECT, DACL_SECURITY_INFORMATION, nullptr, nullptr, nullptr, nullptr);
     return hMap;
 }
 
@@ -43,8 +78,17 @@ DBWinReader::DBWinReader(Timer& timer, ILineBuffer& linebuffer, bool global) :
 {
 	SetDescription(global ? L"Global Win32 Messages" : L"Win32 Messages");
 
-	Win32::SetSecurityInfo(m_dbWinBufferReady.get(), SE_KERNEL_OBJECT, DACL_SECURITY_INFORMATION, nullptr, nullptr, nullptr, nullptr);
-	Win32::SetSecurityInfo(m_dbWinDataReady.get(), SE_KERNEL_OBJECT, DACL_SECURITY_INFORMATION, nullptr, nullptr, nullptr, nullptr);
+	//Option 1:
+	AdjustObjectDACL(m_hBuffer.get());
+	AdjustObjectDACL(m_dbWinBufferReady.get());
+	AdjustObjectDACL(m_dbWinDataReady.get());
+
+	//Option 2:
+	//DeleteObjectDACL(m_hBuffer.get());
+	//DeleteObjectDACL(m_dbWinBufferReady.get());
+	//DeleteObjectDACL(m_dbWinDataReady.get());
+
+	//TODO: Please test this and choose one
 
 	Win32::SetEvent(m_dbWinBufferReady);
 }

--- a/Win32Lib/Win32Lib.cpp
+++ b/Win32Lib/Win32Lib.cpp
@@ -261,6 +261,12 @@ Handle CreateMutex(const SECURITY_ATTRIBUTES* pMutexAttributes, bool initialOwne
 	return hMutex;
 }
 
+void SetSecurityInfo(HANDLE hObject, SE_OBJECT_TYPE ObjectType, SECURITY_INFORMATION SecurityInfo, const PSID psidOwner, const PSID psidGroup, const PACL pDacl, const PACL pSacl) {
+	if (::SetSecurityInfo(hObject, ObjectType, SecurityInfo, psidOwner, psidGroup, pDacl, pSacl) != ERROR_SUCCESS) {
+		ThrowLastError("SetSecurityInfo");
+	}
+}
+
 void WaitForSingleObject(HANDLE hObject)
 {
 	auto rc = ::WaitForSingleObject(hObject, INFINITE);

--- a/include/Win32/Win32Lib.h
+++ b/include/Win32/Win32Lib.h
@@ -14,6 +14,9 @@
 #include <memory>
 #include <vector>
 
+#include <AccCtrl.h>
+#include <Aclapi.h>
+
 #pragma comment(lib, "Win32Lib.lib")
 
 namespace fusion {
@@ -195,6 +198,8 @@ void SetEvent(Handle& hEvent);
 void SetEvent(HANDLE hEvent);
 
 Handle CreateMutex(const SECURITY_ATTRIBUTES* pMutexAttributes, bool initialOwner, const wchar_t* pName);
+
+void SetSecurityInfo(HANDLE hObject, SE_OBJECT_TYPE ObjectType, SECURITY_INFORMATION SecurityInfo, const PSID psidOwner, const PSID psidGroup, const PACL pDacl, const PACL pSacl);
 
 void SetPrivilege(const wchar_t* privilege, bool enablePrivilege);
 void SetPrivilege(HANDLE hToken, const wchar_t* privilege, bool enablePrivilege);


### PR DESCRIPTION
This fix adds the ability to receive messages from other users' processes. For example, running from "Local Service" and "Network Service" built-in accounts.
Prior to this, messages could only be received from the "System" processes, the current user, and possibly the "Administrators" group.

Just try this before and after fix:
psexec.exe -accepteula -e -h -u "nt authority\local service" -i 0 "c:\FolderWithReadPermitedToAll\OutputDebugString-test.exe"

"OutputDebugString-test.exe" just call OutputDebugString("Hello world! It's the Local Service!") 