### PR TITLE
Remove color support from "Include" filter.

### DIFF
--- a/DebugView++/FilterPage.cpp
+++ b/DebugView++/FilterPage.cpp
@@ -49,6 +49,7 @@ bool SupportsColor(FilterType::type filterType)
     switch (filterType)
     {
     case FilterType::Exclude:
+    case FilterType::Include:
         return false;
     default:
         return true;

--- a/DebugView++/LogView.cpp
+++ b/DebugView++/LogView.cpp
@@ -2107,7 +2107,6 @@ bool FilterSupportsColor(FilterType::type value)
 {
     switch (value)
     {
-    case FilterType::Include:
     case FilterType::Highlight:
     case FilterType::Track:
     case FilterType::Stop:


### PR DESCRIPTION
I would very much like to use the "include" filter but the fact that it has precedence over dynamic process colors has been a deal breaker.

Now include filter does not apply text coloring either, very much like the exclude filter. Not a big functionality loss because it is still possible to recolor included lines by defining an additional highlight rule. Perhaps more work, but definitely more flexibility.

Accept PR if it makes sense. Reject if not compatible with project vision.