### PR TITLE
Disregard "Auto Newline" user setting and always assume auto newline in FileReader

### DIFF
--- a/DebugView++Lib/FileReader.cpp
+++ b/DebugView++Lib/FileReader.cpp
@@ -46,6 +46,11 @@ void FileReader::Abort()
     }
 }
 
+bool FileReader::GetAutoNewLine() const
+{
+    return true;
+}
+
 void FileReader::PollThread()
 {
     // FILE_NOTIFY_CHANGE_SIZE is broken on windows vista and above in that it does not

--- a/include/DebugView++Lib/FileReader.h
+++ b/include/DebugView++Lib/FileReader.h
@@ -32,6 +32,7 @@ public:
     HANDLE GetHandle() const override;
     void Notify() override;
     void PreProcess(Line& line) const override;
+    virtual bool GetAutoNewLine() const override;
 
 protected:
     virtual void AddLine(const std::string& line);


### PR DESCRIPTION
This may not be the proper place to fix this but it works nicely at least as a temporary measure. The alternative is a potential DoS when trying to open large files as discussed in #352.

Now FileReader always splits on newlines regardless of what the user selected for "Auto Newline" option from the menu. Fixes #352.