### PR TITLE
Make it possible to override NUGET_PACKAGES_PATH on command line

### DIFF
--- a/cmake/CMakeLists.nuget.cmake
+++ b/cmake/CMakeLists.nuget.cmake
@@ -6,7 +6,7 @@ else()
 	execute_process(COMMAND ${CMAKE_SOURCE_DIR}/utils/nuget.exe restore ${NUGET_SOLUTION} COMMAND_ERROR_IS_FATAL ANY)
 endif()
 
-set(NUGET_PACKAGES_PATH ${CMAKE_SOURCE_DIR}/application/nuget/packages)
+set(NUGET_PACKAGES_PATH ${CMAKE_SOURCE_DIR}/application/nuget/packages CACHE PATH "Directory containing nuget packages")
 
 add_library(nuget_boost INTERFACE)
 target_include_directories(nuget_boost INTERFACE "${NUGET_PACKAGES_PATH}/boost.1.80.0/lib/native/include")


### PR DESCRIPTION
When PackagesRoot is set to some global directory, nuget packages are installed in it and not under application-specific nuget directory, so using the default value of NUGET_PACKAGES_PATH didn't work and CMake configure step failed because it didn't find third-party packages files.

Fix this by allowing to specify -DNUGET_PACKAGES_PATH=$PackagesRoot on CMake command line to override the default value.

----

I've ran into this while working on my other PR and had to make this change as I couldn't build the application without it. I'm not a CMake expert (far from it), but AFAICS this shouldn't break anything and allows the build to work here.