### PR TITLE
Add necessary permissions for packaged applications (fixes #365)

### DIFF
--- a/application/DebugViewppLib/DBWinReader.cpp
+++ b/application/DebugViewppLib/DBWinReader.cpp
@@ -43,14 +43,14 @@ DBWinReader::DBWinReader(Timer& timer, ILineBuffer& linebuffer, bool global) :
     SetDescription(global ? L"Global Win32 Messages" : L"Win32 Messages");
 
     //Option 1:
-    //Win32::AdjustObjectDACL(m_hBuffer.get());
-    //Win32::AdjustObjectDACL(m_dbWinBufferReady.get());
-    //Win32::AdjustObjectDACL(m_dbWinDataReady.get());
+    Win32::AdjustObjectDACL(m_hBuffer.get());
+    Win32::AdjustObjectDACL(m_dbWinBufferReady.get());
+    Win32::AdjustObjectDACL(m_dbWinDataReady.get());
 
     //Option 2:
-    Win32::DeleteObjectDACL(m_hBuffer.get());
-    Win32::DeleteObjectDACL(m_dbWinBufferReady.get());
-    Win32::DeleteObjectDACL(m_dbWinDataReady.get());
+    //Win32::DeleteObjectDACL(m_hBuffer.get());
+    //Win32::DeleteObjectDACL(m_dbWinBufferReady.get());
+    //Win32::DeleteObjectDACL(m_dbWinDataReady.get());
 
     // TODO(jan): Please test this and choose one
 


### PR DESCRIPTION
I didn't do extensive testing, and not sure about any possible regressions caused by switching from Option 2 to Option 1, but from a quick test, adding explicit permissions for "All Application Packages", "All Restricted Application Packages" makes Debugview++ work with UWP apps.

Fixes #365.