### PR TITLE
Use a statically-linked runtime library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 include(CMakeLists.buildnumber)


### PR DESCRIPTION
Otherwise, if the Visual C++ Redistributable isn't installed, the following error message pops up:
![image](https://github.com/CobaltFusion/DebugViewPP/assets/4129781/25185285-6888-421d-a7de-fc89c53d5f85)

This causes the binary size to increase by around 250 KB, e.g. for DebugViewConsole.exe it goes from 447 KB to 695 KB, but I believe that for such a tool, having it functional on any machine for troubleshooting etc. is more important.

BTW a statically-linked runtime library was used in v1.8, but was changed with the introduction of cmake.

Reference for the cmake command:
https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html#variable:CMAKE_MSVC_RUNTIME_LIBRARY

Fixes #396.