### PR TITLE
force wstringbuilder to return a wstring via WStr method

### DIFF
--- a/application/include/CobaltFusion/stringbuilder.h
+++ b/application/include/CobaltFusion/stringbuilder.h
@@ -54,9 +54,9 @@ public:
 
     wstringbuilder& operator<<(const std::string& str)
     {
-        m_ss << WStr(str);
+        m_ss << WStr(str).str();
         return *this;
-    }
+    } 
 
     operator std::wstring() const
     {


### PR DESCRIPTION
After building the project, I ran into a problem that some addresses were displayed in a form of indiscernible pointers. 
<img width="1532" height="324" alt="without" src="https://github.com/user-attachments/assets/97727532-070b-4161-a190-672ca0ca265f" />

After digging for a bit, I found that the problem was that class wstringbuilder couldn't return a proper std::wstring via class WStr. My simple fix makes WStr return a dereferenced wstring, and the addresses are dereferenced correctly.
<img width="1686" height="338" alt="WithMethod" src="https://github.com/user-attachments/assets/ce154fc6-daf4-4c1e-a936-1c3e2bc5bf60" />
