### PR TITLE
Changed the editorconfig encoding setting to utf-8 and added a DbgMsgSrc

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,4 @@ end_of_line = crlf
 charset = latin1
 indent_style = space
 indent_size = 4
+charset = utf-8

--- a/application/DbgMsgSrc/DbgMsgSrc.cpp
+++ b/application/DbgMsgSrc/DbgMsgSrc.cpp
@@ -277,6 +277,22 @@ void EndlessTest()
     }
 }
 
+void EncodingTest()
+{
+    const wchar_t* utf16Message = L"This message is UTF-16 encoded and send through OutputDebugStringW \u65E5\u672C\u8A9E"; // 日本語 UTF-16 encoded
+    OutputDebugStringW(utf16Message);
+
+    // 日本語 😀" encoded as UTF-8 bytes
+    const char* utf8Message = "This message is UTF-8 encoded and send through OutputDebugStringA (with special windows settings): "
+        "\xE6\x97\xA5" // 日 // Ni
+        "\xE6\x9C\xAC" // 本 // Hon
+        "\xE8\xAA\x9E" // 語 // Go
+        " "
+        "\xF0\x9F\x98\x80"; // 😀
+
+    OutputDebugStringA(utf8Message);
+}
+
 void SeparateProcessTest()
 {
     std::cerr << "SeparateProcessTest\n";
@@ -407,6 +423,11 @@ int Main(int argc, char* argv[])
         else if (arg == "-3")
         {
             EndlessTest();
+            return 0;
+        }
+        else if (arg == "-4")
+        {
+            EncodingTest();
             return 0;
         }
         else if (arg == "-s") // run separate process test

--- a/application/DebugViewpp/MainFrame.cpp
+++ b/application/DebugViewpp/MainFrame.cpp
@@ -96,7 +96,7 @@ std::wstring FormatDuration(double seconds)
         return wstringbuilder() << FormatUnits(minutes, L"minute") << L" " << FormatUnits(FloorTo<int>(seconds), L"second");
     }
 
-    static const wchar_t* units[] = {L"s", L"ms", L"\u03BCs", L"ns", nullptr}; // visualstudio is apparently unable to display the micro-sign correctly in UTF-8 encoded files
+    static const wchar_t* units[] = {L"s", L"ms", L"\u03BCs", L"ns", nullptr}; // visualstudio is apparently unable to display the “μs” (microseconds) in UTF-8 encoded files
     const wchar_t** unit = units;
     while (*unit != nullptr && seconds > 0 && seconds < 1)
     {


### PR DESCRIPTION
test, and also fixed the comment on the us (microseconds) unit