### PR TITLE
Fix dropped kernel messages and stale state between driver loads

### DIFF
--- a/application/DebugViewppLib/CMakeLists.txt
+++ b/application/DebugViewppLib/CMakeLists.txt
@@ -49,6 +49,7 @@ PRIVATE
     nuget::wtl
     dv::cobaltfusion
     dv::win32
+    winmm
 )
 
 target_include_directories(${PROJECT_NAME} PUBLIC

--- a/application/DebugViewppLib/KernelReader.cpp
+++ b/application/DebugViewppLib/KernelReader.cpp
@@ -11,6 +11,9 @@
 
 #include <filesystem>
 #include <format>
+
+#include <mmsystem.h> // timeBeginPeriod / timeEndPeriod
+
 namespace fusion {
 namespace debugviewpp {
 
@@ -46,10 +49,13 @@ void KernelReader::StartListening()
         throw std::runtime_error("Could not find the kernel messages driver device name");
     }
 
-    // enable capture
-    DWORD dwOut = 0;
     DWORD dwReturned = 0;
-    BOOL bRet = DeviceIoControl(handle.get(), DBGV_CAPTURE_KERNEL, NULL, 0, &dwOut, sizeof(dwOut), &dwReturned, NULL);
+
+    // flush any stale events left over from a previous session
+    ::DeviceIoControl(handle.get(), DBGV_CLEAR_DISPLAY, NULL, 0, NULL, 0, &dwReturned, NULL);
+
+    DWORD dwOut = 0;
+    BOOL bRet = ::DeviceIoControl(handle.get(), DBGV_CAPTURE_KERNEL, NULL, 0, &dwOut, sizeof(dwOut), &dwReturned, NULL);
     if (!bRet)
     {
         printf("DBGV_CAPTURE_KERNEL failed, err=%d\n", ::GetLastError());
@@ -62,28 +68,37 @@ void KernelReader::StartListening()
 
 void KernelReader::StopListening()
 {
-    BOOL bRet = DeviceIoControl(m_handle.get(), DBGV_UNCAPTURE_KERNEL, NULL, 0, NULL, 0, NULL, NULL);
+    // clear verbose / pass-through bits so the driver is left in a clean state for the next load
+    ::DeviceIoControl(m_handle.get(), DBGV_UNSET_VERBOSE_MESSAGES, NULL, 0, NULL, 0, NULL, NULL);
+    ::DeviceIoControl(m_handle.get(), DBGV_UNSET_PASSTHROUGH, NULL, 0, NULL, 0, NULL, NULL);
+
+    BOOL bRet = ::DeviceIoControl(m_handle.get(), DBGV_UNCAPTURE_KERNEL, NULL, 0, NULL, 0, NULL, NULL);
     if (!bRet)
     {
         printf("DBGV_UNCAPTURE_KERNEL failed, err=%d\n", ::GetLastError());
     }
     m_handle.reset();
     ::free(m_pBuf);
+    m_pBuf = nullptr;
 }
 
 KernelReader::KernelReader(Timer& timer, ILineBuffer& linebuffer) :
-    PolledLogSource(timer, SourceType::Pipe, linebuffer, 1)
+    PolledLogSource(timer, SourceType::Pipe, linebuffer, 1000) // 1ms poll
 {
     SetDescription(L"Kernel Message Reader");
     InstallKernelMessagesDriver(GetDebugviewDriverLocation());
     Signal();
     StartListening();
+    // bump the system timer resolution so the base class sleep_for(1ms) is actually ~1ms
+    // instead of being rounded up to the default Windows scheduler tick
+    ::timeBeginPeriod(1);
     StartThread();
 }
 
 KernelReader::~KernelReader()
 {
     StopListening();
+    ::timeEndPeriod(1);
     UninstallKernelMessagesDriver();
 }
 
@@ -101,19 +116,24 @@ bool KernelReader::AtEnd() const
 
 void KernelReader::Poll()
 {
-    memset(m_pBuf, 0, kernelMessageBufferSize);
-    DWORD dwOut = 0;
-    ::DeviceIoControl(m_handle.get(), DBGV_READ_LOG, NULL, 0, m_pBuf, kernelMessageBufferSize, &dwOut, NULL);
-    if (dwOut == 0)
+    // drain the driver ring until empty; a single IOCTL per poll was dropping
+    // messages whenever the producer outran the poll rate
+    for (;;)
     {
-        return; // no messages to be read
-    }
+        memset(m_pBuf, 0, kernelMessageBufferSize);
+        DWORD dwOut = 0;
+        ::DeviceIoControl(m_handle.get(), DBGV_READ_LOG, NULL, 0, m_pBuf, kernelMessageBufferSize, &dwOut, NULL);
+        if (dwOut == 0)
+        {
+            return; // no messages to be read
+        }
 
-    PLOG_ITEM pNextItem = m_pBuf;
-    while (pNextItem->dwIndex != 0)
-    {
-        AddMessage(0, "kernel", pNextItem->strData);
-        pNextItem = (PLOG_ITEM)((char*)pNextItem + sizeof(LOG_ITEM) + (strlen(pNextItem->strData) + 4) / 4 * 4);
+        PLOG_ITEM pNextItem = m_pBuf;
+        while (pNextItem->dwIndex != 0)
+        {
+            AddMessage(0, "kernel", pNextItem->strData);
+            pNextItem = (PLOG_ITEM)((char*)pNextItem + sizeof(LOG_ITEM) + (strlen(pNextItem->strData) + 4) / 4 * 4);
+        }
     }
 }
 


### PR DESCRIPTION
Hi! First of all, thanks for keeping DebugView++ alive — it's been a daily tool for me for a long time.

On my machine I was seeing kernel-mode messages arrive with visible latency, and the occasional message going missing when the driver produced a burst. I spent some time looking at what `KernelReader` does today and comparing it with Sysinternals DbgView to understand what was going on, and I wanted to share what I found in case it's useful.

The driver doesn't expose an event handle and `DBGV_READ_LOG` is a synchronous IOCTL, so both viewers end up polling. A couple of small things in `KernelReader`'s current shape looked like they could probably be tightened up:

- `PolledLogSource::pollFrequency` is in Hz, so the current value `1` means one poll per second, which seems to explain most of the latency I was seeing. Bumping it to `1000` (≈1 ms interval) helps a lot, and I added `timeBeginPeriod(1)` / `timeEndPeriod(1)` so the 1 ms sleep isn't rounded up to the default scheduler tick. That's why `winmm` is linked in CMake now — happy to split that out if you'd prefer.
- `Poll()` issued a single `DBGV_READ_LOG` per tick, so if the driver produced more than one buffer-worth between polls, the rest got dropped. I changed it to drain the ring until the driver reports 0 bytes, which mirrors what DbgView's read loop does (it tight-loops the IOCTL until empty, bounded by a 300 ms budget, before yielding).
- `DBGV_CLEAR_DISPLAY` is now sent before `DBGV_CAPTURE_KERNEL` so stale events from a previous session aren't replayed into the new one. DbgView does the same on startup.
- On shutdown, verbose / pass-through bits are cleared before `DBGV_UNCAPTURE_KERNEL`, and `m_pBuf` is nulled after `free` to avoid a dangling pointer if start/stop is repeated.

I'm very open to changing any of this — I've only been in this code briefly, so if any of the above is wrong about the design intent, or there's a different direction you'd prefer, I'd be happy to revise. Thanks again for taking a look!