### PR TITLE
build(cmake): mark nuget package includes as SYSTEM to suppress third-party warnings

### DIFF
--- a/cmake/CMakeLists.nuget.cmake
+++ b/cmake/CMakeLists.nuget.cmake
@@ -9,23 +9,23 @@ endif()
 set(NUGET_PACKAGES_PATH ${CMAKE_SOURCE_DIR}/application/nuget/packages CACHE PATH "Directory containing nuget packages")
 
 add_library(nuget_boost INTERFACE)
-target_include_directories(nuget_boost INTERFACE "${NUGET_PACKAGES_PATH}/boost.1.80.0/lib/native/include")
+target_include_directories(nuget_boost SYSTEM INTERFACE "${NUGET_PACKAGES_PATH}/boost.1.80.0/lib/native/include")
 target_link_directories(nuget_boost INTERFACE "${NUGET_PACKAGES_PATH}/boost_date_time-vc143.1.80.0/lib/native")
 target_link_directories(nuget_boost INTERFACE "${NUGET_PACKAGES_PATH}/boost_regex-vc143.1.80.0/lib/native")
 target_link_directories(nuget_boost INTERFACE "${NUGET_PACKAGES_PATH}/boost_system-vc143.1.80.0/lib/native")
 add_library(nuget::boost ALIAS nuget_boost)
 
 add_library(nuget_boost_test INTERFACE)
-target_include_directories(nuget_boost_test INTERFACE "${NUGET_PACKAGES_PATH}/boost.1.80.0/lib/native/include")
+target_include_directories(nuget_boost_test SYSTEM INTERFACE "${NUGET_PACKAGES_PATH}/boost.1.80.0/lib/native/include")
 target_link_directories(nuget_boost_test INTERFACE "${NUGET_PACKAGES_PATH}/boost_unit_test_framework-vc143.1.80.0/lib/native")
 add_library(nuget::boost_test ALIAS nuget_boost_test)
 
 add_library(nuget_snappy "${NUGET_PACKAGES_PATH}/Snappy.1.1.1.7/lib/native/src/snappy-single-file.cpp")
 target_compile_definitions(nuget_snappy PUBLIC SNAPPY_STATIC)
-target_include_directories(nuget_snappy PUBLIC "${NUGET_PACKAGES_PATH}/Snappy.1.1.1.7/lib/native/include")
+target_include_directories(nuget_snappy SYSTEM PUBLIC "${NUGET_PACKAGES_PATH}/Snappy.1.1.1.7/lib/native/include")
 add_library(nuget::snappy ALIAS nuget_snappy)
 
 add_library(nuget_wtl INTERFACE)
-target_include_directories(nuget_wtl INTERFACE "${NUGET_PACKAGES_PATH}/wtl.10.0.10320/lib/native/include")
+target_include_directories(nuget_wtl SYSTEM INTERFACE "${NUGET_PACKAGES_PATH}/wtl.10.0.10320/lib/native/include")
 add_library(nuget::wtl ALIAS nuget_wtl)
 


### PR DESCRIPTION
suppress warnings like
```
D:\a\DebugViewPP\DebugViewPP\application\nuget\packages\boost.1.80.0\lib\native\include\boost\asio\detail\impl\win_iocp_socket_service_base.ipp(629,26): warning C4242: '=': conversion from 'int' to 'ADDRESS_FAMILY', possible loss of data [D:\a\DebugViewPP\DebugViewPP\build\application\DebugViewppLib\DebugView++Lib.vcxproj]
  (compiling source file '../../../application/DebugViewppLib/DbgviewReader.cpp')
  
D:\a\DebugViewPP\DebugViewPP\application\nuget\packages\boost.1.80.0\lib\native\include\boost\asio\impl\serial_port_base.ipp(511,22): warning C4242: '=': conversion from 'const unsigned int' to 'BYTE', possible loss of data [D:\a\DebugViewPP\DebugViewPP\build\application\DebugViewppLib\DebugView++Lib.vcxproj]
  (compiling source file '../../../application/DebugViewppLib/DbgviewReader.cpp')
```