### PR TITLE
feat: add Unicode support and recover tests

### DIFF
--- a/application/CobaltFusionTest/CobaltFusionTest.cpp
+++ b/application/CobaltFusionTest/CobaltFusionTest.cpp
@@ -292,18 +292,17 @@ std::ostream& operator<<(std::ostream& os, const std::chrono::steady_clock::dura
     return os << duration_cast<milliseconds>(p).count() << "ms";
 }
 
-// this test requires the 'Language for non-unicode programs' to be set to 'chinese-simplified'
-// see Run "intl.cpl" -> Administrative -> 'Language for non-unicode programs'
-//BOOST_AUTO_TEST_CASE(RoundTripUnicodeTest)
-//{
-//    auto t1 = ::setlocale(LC_ALL, "chinese-simplified");
-//    BOOST_REQUIRE(t1 != nullptr);    // nulltr means 'could not set locale'
-//
-//    std::wstring chineseLanguage = L"\u4e2d\u6587"; // 中文";
-//    std::string s = Str(chineseLanguage);
-//    std::wstring w = WStr(s);
-//    BOOST_REQUIRE(w == chineseLanguage);
-//}
+BOOST_AUTO_TEST_CASE(RoundTripUnicodeTest)
+{
+    std::wstring unicodeSample = L"Hello, 世界! é/Ω/€ 🚀";
+    std::string s = Str(unicodeSample);
+    std::wstring w = WStr(s);
+    BOOST_REQUIRE(w == unicodeSample);
+
+    std::string sWithBom = "\xEF\xBB\xBF" + s;
+    std::wstring wStripped = WStr(sWithBom);
+    BOOST_REQUIRE(wStripped == unicodeSample);
+}
 
 BOOST_AUTO_TEST_CASE(ThrottleTest)
 {

--- a/application/DebugViewppLib/Line.cpp
+++ b/application/DebugViewppLib/Line.cpp
@@ -14,7 +14,7 @@ Line::Line(double time, FILETIME systemTime, HANDLE handle, const std::string& m
     systemTime(systemTime),
     handle(handle),
     pid(0),
-    message(message),
+    message(Win32::StripUtf8Bom(message)),
     pLogSource(pLogSource)
 {
 }
@@ -25,7 +25,7 @@ Line::Line(double time, FILETIME systemTime, DWORD pid, const std::string& proce
     handle(nullptr),
     pid(pid),
     processName(processName),
-    message(message),
+    message(Win32::StripUtf8Bom(message)),
     pLogSource(pLogSource)
 {
 }

--- a/application/Win32Lib/Win32Lib.cpp
+++ b/application/Win32Lib/Win32Lib.cpp
@@ -118,10 +118,30 @@ ScopedTextAlign::~ScopedTextAlign()
 
 std::wstring MultiByteToWideChar(std::string_view str)
 {
-    int buf_size = static_cast<int>(str.size() + 2);
-    std::vector<wchar_t> buf(buf_size);
-    size_t write_len = ::MultiByteToWideChar(0, 0, str.data(), static_cast<int>(str.size()), buf.data(), buf_size);
-    return std::wstring(buf.data(), buf.data() + write_len);
+    str = StripUtf8Bom(str);
+
+    if (str.empty())
+    {
+        return {};
+    }
+
+    int utf8_len = ::MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, str.data(), static_cast<int>(str.size()), nullptr, 0);
+    if (utf8_len > 0)
+    {
+        std::wstring wstr(utf8_len, L'\0');
+        ::MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, str.data(), static_cast<int>(str.size()), wstr.data(), utf8_len);
+        return wstr;
+    }
+
+    int acp_len = ::MultiByteToWideChar(CP_ACP, 0, str.data(), static_cast<int>(str.size()), nullptr, 0);
+    if (acp_len > 0)
+    {
+        std::wstring wstr(acp_len, L'\0');
+        ::MultiByteToWideChar(CP_ACP, 0, str.data(), static_cast<int>(str.size()), wstr.data(), acp_len);
+        return wstr;
+    }
+
+    return {};
 }
 
 std::wstring MultiByteToWideChar_std(std::string_view str) // supposedly more reliable, but not working.
@@ -134,10 +154,20 @@ std::wstring MultiByteToWideChar_std(std::string_view str) // supposedly more re
 
 std::string WideCharToMultiByte(std::wstring_view str)
 {
-    size_t buf_size = str.size() * 2 + 2;
-    std::vector<char> buf(buf_size);
-    size_t write_len = ::WideCharToMultiByte(0, 0, str.data(), static_cast<int>(str.size()), buf.data(), static_cast<int>(buf.size()), nullptr, nullptr);
-    return std::string(buf.data(), buf.data() + write_len);
+    if (str.empty())
+    {
+        return {};
+    }
+
+    int len = ::WideCharToMultiByte(CP_UTF8, 0, str.data(), static_cast<int>(str.size()), nullptr, 0, nullptr, nullptr);
+    if (len > 0)
+    {
+        std::string res(len, '\0');
+        ::WideCharToMultiByte(CP_UTF8, 0, str.data(), static_cast<int>(str.size()), res.data(), len, nullptr, nullptr);
+        return res;
+    }
+
+    return {};
 }
 
 Win32Error::Win32Error(DWORD error, const std::string& what) :

--- a/application/include/Win32/Win32Lib.h
+++ b/application/include/Win32/Win32Lib.h
@@ -8,6 +8,7 @@
 #include "Utilities.h"
 
 #include <string>
+#include <string_view>
 #include <memory>
 #include <vector>
 #include <system_error>
@@ -177,6 +178,17 @@ class Win32Error : public std::system_error
 public:
     Win32Error(DWORD error, const std::string& what);
 };
+
+inline constexpr std::string_view utf8_bom = "\xEF\xBB\xBF";
+
+inline std::string_view StripUtf8Bom(std::string_view str) noexcept
+{
+    if (str.starts_with(utf8_bom))
+    {
+        str.remove_prefix(utf8_bom.size());
+    }
+    return str;
+}
 
 std::wstring MultiByteToWideChar(std::string_view str);
 std::wstring MultiByteToWideChar_std(std::string_view str);


### PR DESCRIPTION
related #419

showcase:
<img width="1911" height="491" alt="image" src="https://github.com/user-attachments/assets/34ace6ef-cf17-4375-ae14-4134b2ea6aa8" />

(I enabled per-monitor DPI locally so the layout might look a little weird)

---

it works for
```cpp
OutputDebugStringA(u8"Hello, 世界! 🚀\n");
```

to fully support `OutputDebugStringW`, the sender side needs to set
```xml
<activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
```
and then
```cpp
OutputDebugStringW(L"Hello, 世界! 🚀\n");
```

BOM is also stripped in case it breaks filter (e.g. using regex to filter logs starting with xxx)

---

btw a process can only be attached by a single debugger and hence it might not be a good idea to always attach a debugger from DebugView side